### PR TITLE
add plugin hyper-single-instance

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -288,5 +288,12 @@
     "type": "plugin",
     "preview": "https://raw.githubusercontent.com/neil-orans/hyper-savetext/master/screenshots/hyperstore-bg-image.png",
     "dateAdded": "1524611024916"
+  },
+  {
+    "name": "hyper-single-instance",
+    "description": "open new tab instead of create a new app instance when click the system-context-menu or call to hyper.exe",
+    "type": "plugin",
+    "preview": "https://raw.githubusercontent.com/ivanwonder/hyper-single-instance/master/demo.gif",
+    "dateAdded": "1525831601786"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -291,7 +291,7 @@
   },
   {
     "name": "hyper-single-instance",
-    "description": "Open new tab instead of create a new app instance when click the system-context-menu or call to hyper.exe",
+    "description": "Open a new tab instead of a new window instance when opening Hyper.",
     "type": "plugin",
     "preview": "https://raw.githubusercontent.com/ivanwonder/hyper-single-instance/master/demo.gif",
     "dateAdded": "1525831601786"

--- a/plugins.json
+++ b/plugins.json
@@ -291,7 +291,7 @@
   },
   {
     "name": "hyper-single-instance",
-    "description": "open new tab instead of create a new app instance when click the system-context-menu or call to hyper.exe",
+    "description": "Open new tab instead of create a new app instance when click the system-context-menu or call to hyper.exe",
     "type": "plugin",
     "preview": "https://raw.githubusercontent.com/ivanwonder/hyper-single-instance/master/demo.gif",
     "dateAdded": "1525831601786"


### PR DESCRIPTION
An extension which prevents the creation of multiple Hyper.app windows.