### PR TITLE
Add hyper-active-tab plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -329,7 +329,7 @@
   },
   {
     "name": "hyper-active-tab",
-    "description": "Add a symbol to the active tab in your hyper terminal",
+    "description": "Add a symbol to the active tab in your Hyper.app terminal",
     "type": "plugin",
     "preview": "https://raw.githubusercontent.com/lucleray/hyper-active-tab/master/demo/no-theme.png",
     "dateAdded": "1525908495226"

--- a/plugins.json
+++ b/plugins.json
@@ -288,5 +288,12 @@
     "type": "plugin",
     "preview": "https://raw.githubusercontent.com/neil-orans/hyper-savetext/master/screenshots/hyperstore-bg-image.png",
     "dateAdded": "1524611024916"
+  },
+  {
+    "name": "hyper-active-tab",
+    "description": "Add a symbol to the active tab in your hyper terminal",
+    "type": "plugin",
+    "preview": "https://raw.githubusercontent.com/lucleray/hyper-active-tab/master/demo/default.png",
+    "dateAdded": "1525908495226"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -293,7 +293,7 @@
     "name": "hyper-active-tab",
     "description": "Add a symbol to the active tab in your hyper terminal",
     "type": "plugin",
-    "preview": "https://raw.githubusercontent.com/lucleray/hyper-active-tab/master/demo/default.png",
+    "preview": "https://raw.githubusercontent.com/lucleray/hyper-active-tab/master/demo/no-theme.png",
     "dateAdded": "1525908495226"
   }
 ]


### PR DESCRIPTION
A plugin to show a symbol next to the active tab.

[Link to the repo.](https://github.com/lucleray/hyper-active-tab)

![demo](https://raw.githubusercontent.com/lucleray/hyper-active-tab/master/demo/default.png)
