### PR TITLE
Plugin Info Footer Wrong Version. Source Page failing to pull data from Unpkg.

### DIFF
--- a/components/PluginInfo.js
+++ b/components/PluginInfo.js
@@ -42,7 +42,10 @@ export default class PluginInfo extends React.Component {
   }
 
   async componentDidMount() {
-    const plugin = await getPluginInfo(this.props.plugin.name)
+    let pluginName = !!this.props.plugin.meta
+      ? this.props.plugin.meta.name
+      : this.props.plugin.name
+    const plugin = await getPluginInfo(pluginName)
 
     if (plugin !== undefined) {
       await this.setState({

--- a/pages/source.js
+++ b/pages/source.js
@@ -38,7 +38,7 @@ export default class extends React.Component {
     const requestedFile = this.readFileFromURL()
 
     if (requestedFile) {
-      initialFile = `/${requestedFile}`
+      initialFile = `${requestedFile}`
     } else {
       initialFile = this.props.pluginContents.files.find(
         file => file.type === 'file'
@@ -62,7 +62,7 @@ export default class extends React.Component {
 
   async getFileContents(file) {
     const response = await cachedFetch(
-      `https://unpkg.com/${this.props.id}@latest/${file}`,
+      `https://unpkg.com/${this.props.id}@latest/${this.formatFileName(file)}`,
       {},
       'text'
     )


### PR DESCRIPTION
Fixed issues with Plugin Info footer. Fixed bug on Source page where getPluginInfo was returning incorrect value, needed to be given the plugin.meta.name. Added check there.