### PR TITLE
fix search highlighting issues

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -28,10 +28,6 @@ class Layout extends React.Component {
         searchQuery: null,
         originalURL: router.asPath
       })
-    } else {
-      this.setState({
-        originalURL: router.asPath
-      })
     }
   }
 


### PR DESCRIPTION
This PR fixes #65 
The `originURL` was never getting reset and since the highlight was based on the search url, it was never getting reset too