### PR TITLE
[WIP]Use npmjs.com api to fetch package metadata

### DIFF
--- a/components/PluginInfo.js
+++ b/components/PluginInfo.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Gravatar from 'react-gravatar'
 import Link from 'next/link'
+import giturl from 'giturl'
 import InstallModal from './InstallModal'
 import GithubIcon from '../static/github-icon.svg'
 import getPluginInfo from '../lib/get-plugin.js'
@@ -43,7 +44,9 @@ export default class PluginInfo extends React.Component {
   }
 
   async componentDidMount() {
-    const plugin = await getPluginInfo(this.props.plugin.name || this.props.plugin.meta.name)
+    const plugin = await getPluginInfo(
+      this.props.plugin.name || this.props.plugin.meta.name
+    )
 
     if (plugin !== undefined) {
       await this.setState({
@@ -78,7 +81,7 @@ export default class PluginInfo extends React.Component {
   render() {
     const { plugin } = this.props
 
-    if (this.state && (!this.state.plugin || !this.state.plugin.collected)) {
+    if (this.state && !this.state.plugin) {
       return (
         <React.Fragment>
           <InstallModal
@@ -139,37 +142,30 @@ export default class PluginInfo extends React.Component {
           <div className="plugin-info__author border-followed">
             <Gravatar
               className="plugin-info__avatar"
-              email={this.state.plugin.collected.metadata.publisher.email}
+              email={this.state.plugin._npmUser.email}
             />
-            <span>
-              {this.state.plugin.collected.metadata.publisher.username}
-            </span>
+            <span>{this.state.plugin._npmUser.name}</span>
           </div>
 
-          <span className="plugin-info__downloads border-followed">
-            {this.state.plugin.collected.npm.downloads[2].count.toLocaleString()}{' '}
-            downloads in the last month
-          </span>
-
-          {this.state.plugin.collected.metadata.links.repository && (
+          {this.state.plugin.repository.url && (
             <a
               className="plugin-info__github-link"
               target="_blank"
-              href={this.state.plugin.collected.metadata.links.repository}
+              href={giturl.parse(this.state.plugin.repository.url)}
             >
               <GithubIcon />
             </a>
           )}
 
           <Link
-            href={`/source?id=${this.state.plugin.collected.metadata.name}`}
-            as={`/plugins/${this.state.plugin.collected.metadata.name}/source`}
+            href={`/source?id=${this.state.plugin.name}`}
+            as={`/plugins/${this.state.plugin.name}/source`}
           >
             <a className="plugin-info__link">View source code</a>
           </Link>
 
           <div className="plugin-info__version">
-            Version {this.state.plugin.collected.metadata.version}
+            Version {this.state.plugin.version}
           </div>
 
           <a className="plugin-info__install" onClick={this.openInstallModal}>

--- a/lib/get-plugin.js
+++ b/lib/get-plugin.js
@@ -7,9 +7,9 @@ export default async (name, { meta = false } = { meta }) => {
 
   if (!meta) {
     try {
-      result = await cachedFetch(`https://api.npms.io/v2/package/${name}`)
+      result = await cachedFetch(`https://registry.npmjs.com/${name}/latest`)
     } catch (err) {
-      console.error('Failed to recieve package information from npms.io', err)
+      console.error('Failed to recieve package information from npmjs.com', err)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "babel-plugin-inline-react-svg": "^1.0.1",
     "escape-html": "^1.0.3",
+    "giturl": "^1.0.1",
     "isomorphic-unfetch": "^3.0.0",
     "lodash.debounce": "^4.0.8",
     "lscache": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,6 +2658,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+giturl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/giturl/-/giturl-1.0.1.tgz#926c69bda5c48a3d8f74254e99f826835e6a4aa0"
+  integrity sha512-wQourBdI13n8tbjcZTDl6k+ZrCRMU6p9vfp9jknZq+zfWc8xXNztpZFM4XkPHVzHcMSUZxEMYYKZjIGkPlei6Q==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"


### PR DESCRIPTION
closes #74 

remove package downloads info, because of npmjs.com API don't provide.