### PR TITLE
Add GitHub Auth token for higher rate limit

### DIFF
--- a/now.json
+++ b/now.json
@@ -7,5 +7,8 @@
     {"src": "/plugins/(?<id>[^/]+)$", "dest": "/plugin?id=$id"},
     {"src": "/plugins/(?<id>[^/]+)/source$", "dest": "/source?id=$id"},
     {"src": "/(.*)", "dest": "/$1"}
-  ]
+  ],
+  "env": {
+    "GITHUB_TOKEN": "@github-auth-token"
+  }
 }

--- a/now.json
+++ b/now.json
@@ -9,6 +9,6 @@
     {"src": "/(.*)", "dest": "/$1"}
   ],
   "env": {
-    "GITHUB_TOKEN": "@github-auth-token"
+    "GITHUB_TOKEN": "@hyper-github-auth-token"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -160,7 +160,11 @@ export default class Index extends React.Component {
 
     const releases = await cachedFetch(
       `https://api.github.com/repos/zeit/hyper/releases`,
-      {},
+      {
+        headers: {
+          Authorization: `token ${process.env.GITHUB_TOKEN}`
+        }
+      },
       'json'
     )
 


### PR DESCRIPTION
This pull request adds a GitHub auth token to increase the rate limit to 5000 requests per hour, instead of 60. https://developer.github.com/v3/#rate-limiting