### PR TITLE
Update og:url meta for blog page

### DIFF
--- a/pages/blog.js
+++ b/pages/blog.js
@@ -19,7 +19,7 @@ class Blog extends React.Component {
           <meta property="twitter:site" content="@zeithq" />
           <meta property="og:title" content="Hyper™" />
           <meta property="og:type" content="website" />
-          <meta property="og:url" content="https://hyper.is" />
+          <meta property="og:url" content="https://hyper.is/blog" />
           <meta
             property="description"
             content="Hyper 3: A cross-platform HTML/JS/CSS terminal"


### PR DESCRIPTION
There's a [sweet image use for the `og:image`](https://hyper.is/static/blog/hyper-3-twitter-card.png) on the blog, which is picked up by Twitter no problem:

<p align="center">
  <img src="https://user-images.githubusercontent.com/121322/57249625-4b755a80-6ffa-11e9-833a-c8f076273bd7.png" width="65%">
</p>

However, Facebook and LinkedIn (and some other things) won't show that image when the URL is shared because of the current `og:url` value. This PR should fix that right up 🤘 