### PR TITLE
Add hyper-witchhazel theme

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -595,5 +595,20 @@
       "#0095FF"
     ],
     "dateAdded": "1558342235115"
+  },
+  {
+    "name": "hyper-witchhazel",
+    "description": "A dark & feminine color scheme.",
+    "type": "theme",
+    "preview": "https://raw.githubusercontent.com/metalcanine/hyper-witchhazel/master/assets/screenshot.png",
+    "colors": [
+      "#FF857F",
+      "#C2FFDF",
+      "#FFF352",
+      "#CEB1FF",
+      "#FFB8D1",
+      "#1BC5E0"
+    ],
+    "dateAdded": "1576608213667"
   }
 ]


### PR DESCRIPTION
This adds a version of Thea Flowers' [Witch Hazel](https://witchhazel.thea.codes/) theme to hyper.js to match the sublime, vscode, and jetbrains Witch Hazel themes. Hope you like it! 💖 

![Screen Shot 2019-12-17 at 10 28 33 AM](https://user-images.githubusercontent.com/2977066/71025608-37c7c180-20bc-11ea-8a20-f03cb559d9b2.png)
